### PR TITLE
328: Add nominal target calculation (CW-BR13)

### DIFF
--- a/app/points/calculate-nominal-target.js
+++ b/app/points/calculate-nominal-target.js
@@ -1,0 +1,16 @@
+const OM_TYPE_IDS = require('./constants/offender-manager-type-ids')
+const DefaultNominalTargets = require('./domain/default-nominal-targets')
+
+module.exports = function (offenderManagerTypeId, defaultNominalTargets) {
+  if (!(defaultNominalTargets instanceof DefaultNominalTargets)) {
+    throw new Error('defaultNominalTargets should be an instance of DefaultNominalTargets')
+  }
+
+  var target = defaultNominalTargets.po
+
+  if (offenderManagerTypeId === OM_TYPE_IDS.PSO) {
+    target = defaultNominalTargets.pso
+  }
+
+  return target
+}

--- a/app/points/constants/offender-manager-type-ids.js
+++ b/app/points/constants/offender-manager-type-ids.js
@@ -1,0 +1,3 @@
+module.exports = {
+  PSO: 2
+}

--- a/app/points/domain/default-nominal-targets.js
+++ b/app/points/domain/default-nominal-targets.js
@@ -1,0 +1,15 @@
+const assertNumber = require('./validation/assert-number')
+
+class DefaultNominalTargets {
+  constructor (psoTarget, poTarget) {
+    this.pso = psoTarget
+    this.po = poTarget
+    this.isValid()
+  }
+  isValid () {
+    assertNumber(this.pso, 'PSO')
+    assertNumber(this.po, 'PO')
+  }
+}
+
+module.exports = DefaultNominalTargets

--- a/test/unit/points/domain/test-default-nominal-targets.js
+++ b/test/unit/points/domain/test-default-nominal-targets.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect
+const DefaultNominalTargets = require('../../../../app/points/domain/default-nominal-targets')
+
+describe('points/domain/DefaultNominalTargets', function () {
+  it('thows an error when any property is undefined', function () {
+    expect(function () { new DefaultNominalTargets(undefined, 1) }).to.throw(Error)
+    expect(function () { new DefaultNominalTargets(1, undefined) }).to.throw(Error)
+  })
+  it('thows an error when any property is not a number', function () {
+    expect(function () { new DefaultNominalTargets('String', 1) }).to.throw(Error)
+    expect(function () { new DefaultNominalTargets(1, 'String') }).to.throw(Error)
+  })
+  it('doesn\'t thow an error when all properties are numbers', function () {
+    expect(function () { new DefaultNominalTargets(1, 1) }).not.to.throw(Error)
+  })
+  it('correctly retrieves all fields', function () {
+    var defaultNominalTargets = new DefaultNominalTargets(1, 2)
+    expect(defaultNominalTargets.pso).to.equal(1)
+    expect(defaultNominalTargets.po).to.equal(2)
+  })
+})

--- a/test/unit/points/test-calculate-nominal-target.js
+++ b/test/unit/points/test-calculate-nominal-target.js
@@ -1,0 +1,28 @@
+const expect = require('chai').expect
+const OM_TYPE_IDS = require('../../../app/points/constants/offender-manager-type-ids')
+const DefaultNominalTargets = require('../../../app/points/domain/default-nominal-targets')
+
+const calculateNominalTarget = require('../../../app/points/calculate-nominal-target')
+
+describe('points/calculate-nominal-target', function () {
+  const PSO_TARGET = 1
+  const PO_TARGET = 2
+  const DEFAULT_TARGETS = new DefaultNominalTargets(PSO_TARGET, PO_TARGET)
+
+  it('returns default target for PSO when PSO type ID is supplied', function () {
+    expect(calculateNominalTarget(OM_TYPE_IDS.PSO, DEFAULT_TARGETS)).to.equal(PSO_TARGET)
+  })
+
+  it('returns default target for PO when any other OM type ID is supplied', function () {
+    expect(calculateNominalTarget(0, DEFAULT_TARGETS)).to.equal(PO_TARGET)
+    expect(calculateNominalTarget(100, DEFAULT_TARGETS)).to.equal(PO_TARGET)
+  })
+
+  it('throws an error when the default targets object is not an instance of DefaultNominalTargets', function () {
+    expect(function(){calculateNominalTarget(0, {})}).to.throw(Error)
+  })
+
+  it('throws an error when the default targets object undefined', function () {
+    expect(function(){calculateNominalTarget(0, undefined)}).to.throw(Error)
+  })
+})


### PR DESCRIPTION
This also includes the addition of a DefaultNominalTargets domain object. The
purpose of this object is store the system wide nominal targets for PSOs and
POs.