### PR TITLE
332: Test that any missing argument throws an error

### DIFF
--- a/test/unit/points/domain/test-tiers.js
+++ b/test/unit/points/domain/test-tiers.js
@@ -1,28 +1,34 @@
  /* eslint-disable no-new */
+ /* eslint-disable new-parens */
 const expect = require('chai').expect
 const Tiers = require('../../../../app/points/domain/tiers')
 const pointsHelper = require('../../../helpers/points-helper')
 const Locations = require('../../../../app/staging/constants/locations')
 
 describe('points/domain/Tiers', function () {
-  it('throws an error when any property is undefined', function () {
-    expect(function () {
-      new Tiers(Locations.COMMUNITY,
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      undefined,
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject(),
-      pointsHelper.getTestTiersObject())
-    }).to.throw(Error)
+  const NUMBER_OF_TIERS_IN_WORKLOAD = 8
+  var validArgumentList = [Locations.COMMUNITY]
+
+  for (var i = 0; i < NUMBER_OF_TIERS_IN_WORKLOAD; i++) {
+    validArgumentList.push(pointsHelper.getTestTierObject())
+  }
+
+  it('throws an error when any argument undefined', function () {
+    for (var j = 1; j < validArgumentList.length; j++) {
+      // slice(0) can be used in order to deep copy arrays
+      var args = validArgumentList.slice(0)
+      args[j] = undefined
+
+      expect(function () {
+        new Tiers(...args)
+      }).to.throw(Error)
+    }
   })
+
   it('all fields can be retrieved', function () {
-    var tiers = pointsHelper.getTestTiersObject(Locations.COMMUNITY)
+    var tiers = new Tiers(...validArgumentList)
     expect(tiers.location).to.be.a('string')
+    expect(tiers.untiered).to.be.an('object')
     expect(tiers.d2).to.be.an('object')
     expect(tiers.d1).to.be.an('object')
     expect(tiers.c2).to.be.an('object')


### PR DESCRIPTION
As javascript gives so little assurance about object types we need to ensure
that our objects are as we expect when they are constructed. This can lead to a
lot of unit tests with duplicate code.

This is an approach which reduces the amount of code required to test all of the
parameters.