### PR TITLE
Fix/wmt 0022/issue with blank grade

### DIFF
--- a/app/context-map/om-grade-code.js
+++ b/app/context-map/om-grade-code.js
@@ -7,7 +7,7 @@ module.exports = function (omGradeCode) {
     'M', 'CRCM', 'NPSM', 'N', 'CRCN', 'NPSN', 'O', 'CRCO', 'NPSO'
   ]
   var spoList = ['C', 'CRCC', 'NPSC']
-  var tpoList = ['K', 'CRCK', 'NPSK', 'L', 'CRCL', 'NPSL', 'P', 'CRCP', 'NPSP']
+  var tpoList = ['K', 'CRCK', 'NPSK', 'L', 'CRCL', 'NPSL', 'P', 'CRCP', 'NPSP', 'NPQF']
   var psoList = ['Y', 'CRCY', 'NPSY', 'Z', 'CRCZ', 'NPSZ', 'Q', 'CRCQ', 'NPSQ']
 
   var dmyList = [

--- a/app/context-map/om-grade-code.js
+++ b/app/context-map/om-grade-code.js
@@ -14,7 +14,7 @@ module.exports = function (omGradeCode) {
     '-1', 'A', 'CRCA', 'NPSA', 'B', 'CRCB', 'NPSB', 'R', 'CRCR', 'NPSR', 'S',
     'CRCS', 'NPSS', 'T', 'CRCT', 'NPST', 'OG01', 'CRC1', 'NPS1', 'OG02', 'CRC2',
     'NPS2', 'OG03', 'CRC3', 'NPS3', 'OG04', 'CRC4', 'NPS4', 'OG05', 'CRC5',
-    'NPS5', 'OG06', 'CRC6', 'NPS6', '', null
+    'NPS5', 'OG06', 'CRC6', 'NPS6', '', null, undefined, ' '
   ]
 
   if (poList.includes(omGradeCode)) {


### PR DESCRIPTION
Added missing type definitions. At the moment if the _space_ grade is in the extract, and the offender manager is new, because _space_ is not defined, they get the initialised grade, blank